### PR TITLE
fix(utxos): Reverting changes

### DIFF
--- a/src/routes/v1/electrumx.js
+++ b/src/routes/v1/electrumx.js
@@ -159,7 +159,7 @@ class Electrum {
   async _utxosFromElectrumx (address) {
     try {
       // Convert the address to a scripthash.
-      // const scripthash = _this.addressToScripthash(address)
+      const scripthash = _this.addressToScripthash(address)
 
       if (!_this.isReady) {
         throw new Error(
@@ -170,7 +170,7 @@ class Electrum {
       // Query the utxos from the ElectrumX server.
       const electrumResponse = await _this.electrumx.request(
         'blockchain.scripthash.listunspent',
-        address
+        scripthash
       )
       // console.log(
       //   `electrumResponse: ${JSON.stringify(electrumResponse, null, 2)}`


### PR DESCRIPTION
This PR reverts the prototype code changes that were intended to fix #13. While those changes first appeared to work, they actually just not throwing errors. The change was not returning UTXOs for any address.